### PR TITLE
Set envvar `FLAGS_SECRET` to use Vercrl feature flag

### DIFF
--- a/terraform/env_vars.tf
+++ b/terraform/env_vars.tf
@@ -38,6 +38,11 @@ resource "vercel_project_environment_variables" "production" {
       value  = var.sentry_auth_token
       target = ["production"]
     },
+    {
+      key    = "FLAGS_SECRET"
+      value  = var.vercel_flags_secret
+      target = ["production"]
+    },
   ]
 }
 
@@ -79,6 +84,11 @@ resource "vercel_project_environment_variables" "preview" {
       value  = var.sentry_auth_token
       target = ["preview"]
     },
+    {
+      key    = "FLAGS_SECRET"
+      value  = var.vercel_flags_secret
+      target = ["preview"]
+    },
   ]
 }
 
@@ -113,6 +123,11 @@ resource "vercel_project_environment_variables" "development" {
     {
       key    = "NEXT_PUBLIC_USE_IN_MEMORY_REPOSITORY"
       value  = "false"
+      target = ["development"]
+    },
+    {
+      key    = "FLAGS_SECRET"
+      value  = var.vercel_flags_secret
       target = ["development"]
     },
   ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,3 +51,9 @@ variable "sentry_auth_token" {
   type        = string
   sensitive   = true
 }
+
+variable "vercel_flags_secret" {
+  description = "secret to use Vercel feature flag functionality"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured Vercel feature-flag support across production, preview, and development by adding the necessary secret and environment entries so flags can be managed consistently in all deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->