### PR TITLE
chore: redirect to rindrics.com

### DIFF
--- a/terraform/domains.tf
+++ b/terraform/domains.tf
@@ -3,20 +3,10 @@ resource "vercel_project_domain" "rindrics_com" {
   domain     = "stock-assessment.rindrics.com"
 }
 
-import {
-  to = vercel_project_domain.rindrics_com
-  id = "${data.vercel_project.main.id}/stock-assessment.rindrics.com"
-}
-
 resource "vercel_project_domain" "learn_to_live" {
   project_id = data.vercel_project.main.id
   domain     = "stock-assessment.learn-to.live"
 
   redirect             = vercel_project_domain.rindrics_com.domain
   redirect_status_code = 308
-}
-
-import {
-  to = vercel_project_domain.learn_to_live
-  id = "${data.vercel_project.main.id}/stock-assessment.learn-to.live"
 }

--- a/terraform/domains.tf
+++ b/terraform/domains.tf
@@ -11,6 +11,9 @@ import {
 resource "vercel_project_domain" "learn_to_live" {
   project_id = data.vercel_project.main.id
   domain     = "stock-assessment.learn-to.live"
+
+  redirect             = vercel_project_domain.rindrics_com.domain
+  redirect_status_code = 308
 }
 
 import {


### PR DESCRIPTION
### **User description**
related to #157


___

### **PR Type**
Enhancement


___

### **Description**
- Configure domain redirect from learn-to.live to rindrics.com

- Remove Terraform import blocks for domain resources

- Set HTTP 308 redirect status code for permanent redirect


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["learn-to.live domain"] -- "308 redirect" --> B["rindrics.com domain"]
  C["Remove import blocks"] --> D["Simplified Terraform config"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>domains.tf</strong><dd><code>Add domain redirect and remove import blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/domains.tf

<ul><li>Removed import blocks for both <code>vercel_project_domain</code> resources<br> <li> Added redirect configuration to <code>learn_to_live</code> domain resource<br> <li> Set <code>redirect</code> to point to <code>rindrics_com.domain</code><br> <li> Set <code>redirect_status_code</code> to 308 for permanent redirect</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/mikazuki-munechika/pull/158/files#diff-e5558c0a29c089133b38efda95032b08e3591148cafb81c28d28eead23b2ad94">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain redirect configuration. A domain is now configured to permanently redirect to another domain using an HTTP 308 status code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->